### PR TITLE
update badge color for Chrome breakage

### DIFF
--- a/background.js
+++ b/background.js
@@ -40,7 +40,7 @@ Reload.prototype.set_chrome_badge = function() {
 		// Tab is no longer auto-reloading.
 		badge_text = '';
 	} else if (g_should_display_badge_countdown && this.next_reload_timestamp > 0) {
-		badge_color = '#4e9a06';
+		badge_color = '#448a00';
 		var delta = Math.round((this.next_reload_timestamp - Date.now()) / 1000);
 		if (delta > 0) {
 			badge_text = seconds_to_badge_text(delta);


### PR DESCRIPTION
fixes #9 

Just prior to version 103, Chrome updated their badge handling code in an attempt to auto-detect the badge background color and set the badge text color to maintain appropriate contrast.  It does not work correctly, however, with the original green background color of this extension, and the text is set to black, which is more or less unreadable.

This PR tweaks the green background color to be slightly darker, to force the text color back to white.